### PR TITLE
Return interface from OccCmdRunnerFactory

### DIFF
--- a/NextCloudSmbChangeListener/Factories/OccCmdRunnerFactory.cs
+++ b/NextCloudSmbChangeListener/Factories/OccCmdRunnerFactory.cs
@@ -10,7 +10,7 @@ public interface IOccCmdRunnerFactory
     /// <summary>
     /// Создаёт исполнителя OCC-команд для указанного контейнера.
     /// </summary>
-    OccCmdRunner Create(string dockerContainer);
+    IOccCmdRunner Create(string dockerContainer);
 }
 
 /// <summary>
@@ -18,6 +18,6 @@ public interface IOccCmdRunnerFactory
 /// </summary>
 public class OccCmdRunnerFactory(ILogger<OccCmdRunner> logger) : IOccCmdRunnerFactory
 {
-    public OccCmdRunner Create(string dockerContainer)
-        => new (dockerContainer, logger);
+    public IOccCmdRunner Create(string dockerContainer)
+        => new OccCmdRunner(dockerContainer, logger);
 }


### PR DESCRIPTION
## Summary
- modify `OccCmdRunnerFactory` to return `IOccCmdRunner` instead of concrete type

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68685b67ad048325931d834fb856b26a